### PR TITLE
Ability to pass "data" to the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Terminal::wait();
 If you want to know why it's better to wait for the command to complete, you may read these [Symfony notes](https://symfony.com/doc/current/components/process.html#running-processes-asynchronously).
  -->
 # Data
+
 If you need to pass any data to your command line, it's better to bind it using the `with` method.
 Terminal can escape and prepare the values for you. Reference these values using the `{{ $key }}` syntax.
 

--- a/README.md
+++ b/README.md
@@ -136,9 +136,8 @@ Terminal::wait();
 If you want to know why it's better to wait for the command to complete, you may read these [Symfony notes](https://symfony.com/doc/current/components/process.html#running-processes-asynchronously).
  -->
 # Data
-
 If you need to pass any data to your command line, it's better to bind it using the `with` method.
-This way, Terminal can escape and preapre the values for you. You can reference these values with the `{{ $key }}` syntax.
+Terminal can escape and prepare the values for you. Reference these values using the `{{ $key }}` syntax.
 
 ```php
 Terminal::with([
@@ -147,7 +146,7 @@ Terminal::with([
 ])->run('echo Hello, {{ $firstname}} {{ $lastname }}');
 ```
 
-Alternatively, you may pass the key-value pairs in a separate parameters.
+Alternatively, you may pass the key-value pairs in separate parameters.
 
 ```php
 Terminal::with('firstname', 'John')

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ An Elegant wrapper around Symfony's Process component.
     - [Output Stream (Recommended)](#output-stream)
     - [Output Lines](#output-lines)
     - [Throwing Exceptions](#throwing-exceptions)
+- [Data](#data)
 - [Working Directory](#working-directory)
 - [Timeout](#timeout)
 - [Retries](#retries)
@@ -134,6 +135,26 @@ Terminal::wait();
 
 If you want to know why it's better to wait for the command to complete, you may read these [Symfony notes](https://symfony.com/doc/current/components/process.html#running-processes-asynchronously).
  -->
+# Data
+
+If you need to pass any data to your command line, it's better to bind it using the `with` method.
+This way, Terminal can escape and preapre the values for you. You can reference these values with the `{{ $key }}` syntax.
+
+```php
+Terminal::with([
+    'firstname' => 'John',
+    'lastname' => 'Doe',
+])->run('echo Hello, {{ $firstname}} {{ $lastname }}');
+```
+
+Alternatively, you may pass the key-value pairs in a separate parameters.
+
+```php
+Terminal::with('firstname', 'John')
+        ->with('lastname', 'Doe')
+        ->run('echo Hello, {{ $firstname}} {{ $lastname }}');
+```
+
 # Working Directory
 
 If you would like to change the current working directory from which

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -357,7 +357,7 @@ class Builder
      * @param  mixed  $command
      * @return string
      */
-    protected function prepareCommand(string $command)
+    protected function prepareCommand($command)
     {
         if (! is_string($command)) {
             return $command;

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -359,7 +359,7 @@ class Builder
      */
     protected function prepareCommand(string $command)
     {
-        if (! is_string($command) || empty($this->with)) {
+        if (! is_string($command)) {
             return $command;
         }
 

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -195,35 +195,7 @@ class Builder
      */
     public function with($key, $value = null)
     {
-        if (is_array($key)) {
-            return $this->setWith($key);
-        }
-
-        return $this->mergeWith([$key => $value]);
-    }
-
-    /**
-     * Set command data bindings.
-     *
-     * @param array  $with
-     * @return $this
-     */
-    public function setWith(array $with)
-    {
-        $this->with = $with;
-
-        return $this;
-    }
-
-    /**
-     * Merge command bindings.
-     *
-     * @param  array  $with
-     * @return $this
-     */
-    public function mergeWith(array $with)
-    {
-        $this->with = array_merge($this->with, $with);
+        $this->with = array_merge($this->with, is_array($key) ? $key : [$key => $value]);
 
         return $this;
     }

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -5,6 +5,7 @@ namespace TitasGailius\Terminal;
 use DateTime;
 use DateInterval;
 use BadMethodCallException;
+use InvalidArgumentException;
 use Symfony\Component\Process\Process;
 
 class Builder
@@ -57,6 +58,13 @@ class Builder
      * @var array|null
      */
     protected $retries = [1, 0];
+
+    /**
+     * Command data bindings.
+     *
+     * @var array
+     */
+    protected $with = [];
 
     /**
      * Builder extensions.
@@ -179,6 +187,48 @@ class Builder
     }
 
     /**
+     * Bind command data.
+     *
+     * @param  mied  $key
+     * @param  mixed  $value
+     * @return $this
+     */
+    public function with($key, $value = null)
+    {
+        if (is_array($key)) {
+            return $this->setWith($key);
+        }
+
+        return $this->mergeWith([$key => $value]);
+    }
+
+    /**
+     * Set command data bindings.
+     *
+     * @param array  $with
+     * @return $this
+     */
+    public function setWith(array $with)
+    {
+        $this->with = $with;
+
+        return $this;
+    }
+
+    /**
+     * Merge command bindings.
+     *
+     * @param  array  $with
+     * @return $this
+     */
+    public function mergeWith(array $with)
+    {
+        $this->with = array_merge($this->with, $with);
+
+        return $this;
+    }
+
+    /**
      * Execute a given command.
      *
      * @param  mixed $command
@@ -289,7 +339,7 @@ class Builder
     public function process()
     {
         $parameters = [
-            $command = $this->command,
+            $command = $this->prepareCommand($this->command),
             $this->cwd,
             $this->environmentVariables,
             $this->input,
@@ -299,6 +349,25 @@ class Builder
         return is_string($command)
             ? Process::fromShellCommandline(...$parameters)
             : new Process(...$parameters);
+    }
+
+    /**
+     * Prepare a given command.
+     *
+     * @param  mixed  $command
+     * @return string
+     */
+    protected function prepareCommand(string $command)
+    {
+        if (! is_string($command) || empty($this->with)) {
+            return $command;
+        }
+
+        return preg_replace_callback('/\{\{\s?\$(\w+)\s?\}\}/u', function ($matches) use ($command) {
+            $this->environmentVariables[$key = 'terminal_'.$matches[1]] = $this->with[$matches[1]] ?? '';
+
+            return sprintf('"${:%s}"', $key);
+        }, $command);
     }
 
     /**

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -196,6 +196,25 @@ class BuilderTest extends TestCase
     }
 
     /**
+     * Test that the "with" command prepares the command correctly.
+     *
+     * @return void
+     */
+    public function testWith()
+    {
+        $process = (new Builder)->with([
+            'foo' => 'World',
+        ])->command('echo Hello, {{ $foo }}')->process();
+
+        $this->assertEquals('echo Hello, "${:terminal_foo}"', $process->getCommandLine());
+        $this->assertEquals(['terminal_foo' => 'World'], $process->getEnv());
+
+        $process->run();
+
+        $this->assertEquals("Hello, World\n", $process->getOutput());
+    }
+
+    /**
      * Create a new builder instance with a mocked process instance.
      *
      * @param  callable $mocker

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -200,7 +200,7 @@ class BuilderTest extends TestCase
      *
      * @return void
      */
-    public function testWith()
+    public function testData()
     {
         $process = (new Builder)->with([
             'foo' => 'World',
@@ -212,6 +212,18 @@ class BuilderTest extends TestCase
         $process->run();
 
         $this->assertEquals("Hello, World\n", $process->getOutput());
+    }
+
+    public function testDataWithMissingBinding()
+    {
+        $process = (new Builder)->command('echo Hello, {{ $foo }}')->process();
+
+        $this->assertEquals('echo Hello, "${:terminal_foo}"', $process->getCommandLine());
+        $this->assertEquals(['terminal_foo' => ''], $process->getEnv());
+
+        $process->run();
+
+        $this->assertEquals("Hello, \n", $process->getOutput());
     }
 
     /**


### PR DESCRIPTION
# Data

If you need to pass any data to your command line, it's better to bind it using the `with` method.
Terminal can escape and prepare the values for you. Reference these values using the `{{ $key }}` syntax.

```php
Terminal::with([
    'firstname' => 'John',
    'lastname' => 'Doe',
])->run('echo Hello, {{ $firstname}} {{ $lastname }}');
```

Alternatively, you may pass the key-value pairs in separate parameters.

```php
Terminal::with('firstname', 'John')
        ->with('lastname', 'Doe')
        ->run('echo Hello, {{ $firstname}} {{ $lastname }}');
```
