### PR TITLE
fixing undefined property / typo

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -314,7 +314,7 @@ class Builder
             $command = $this->prepareCommand($this->command),
             $this->cwd,
             $this->environmentVariables,
-            $this->input,
+            $this->output,
             $this->getSeconds($this->timeout)
         ];
 


### PR DESCRIPTION
Noticed an undefined property exception when attempting to include this package in another project referencing what _looks like_ it should be another, similarly named property.