### PR TITLE
Fix Builder Proxy

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -394,8 +394,8 @@ class Builder
             return static::$extensions[$method]($this);
         }
 
-        if (method_exists($this->process(), $method)) {
-            return $this->process()->{$method}(...$parameters);
+        if (method_exists($process = $this->process(), $method)) {
+            return $process->{$method}(...$parameters);
         }
 
         throw new BadMethodCallException(sprintf(

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -227,6 +227,22 @@ class BuilderTest extends TestCase
     }
 
     /**
+     * Test that missing methods are passed to the Proccess instance.
+     *
+     * @return void
+     */
+    public function testBuilderProxy()
+    {
+        $builder = $this->builderWithMockedProccess(function ($mock) {
+            $mock->shouldReceive('getPid')
+                ->once()
+                ->andReturn(123);
+        });
+
+        $this->assertEquals(123, $builder->getPid());
+    }
+
+    /**
      * Create a new builder instance with a mocked process instance.
      *
      * @param  callable $mocker


### PR DESCRIPTION
There was a typo when proxying builder methods to the Process instance.