### PR TITLE
Use symfony/process version ~4.0|~5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "symfony/process": "^5.0"
+        "symfony/process": "~4.0|~5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",


### PR DESCRIPTION
Update symfony/process version constraint to allow for installation in Laravel 6 & 7 projects.

Fix #13 