### PR TITLE
Laravel & Symfony console commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ An Elegant wrapper around Symfony's Process component.
     - [Output to Array](#output-to-array)
     - [Output Stream (Recommended)](#output-stream)
     - [Output Lines](#output-lines)
-    - [Output from Symfony Console Command](#output-from-symfony-console-command)
-    - [Output from Laravel Artisan Command](#output-from-laravel-artisan-command)
+    - [Output via Laravel Artisan Command](#output-via-laravel-artisan-command)
+    - [Output via Symfony Console Command](#output-via-symfony-console-command)
     - [Throwing Exceptions](#throwing-exceptions)
 - [Data](#data)
 - [Working Directory](#working-directory)
@@ -106,19 +106,7 @@ Alternatively, you may use the `content` method to get the contents of the line:
 $line->content();
 ```
 
-### Output from Symfony Console Command
-
-If you are running Terminal from the Symfony's console command, you may display the output by
-passing an instance of an output to the `output` method:
-
-```php
-protected function execute(InputInterface $input, OutputInterface $output)
-{
-    Terminal::output($output)->run('echo Hello, World');
-}
-```
-
-### Output from Laravel Artisan Command
+### Output via Laravel Artisan Command
 
 If you are running Terminal from the Laravel's Artisan command, you may display the output by
 passing an instance of a command to the `output` method:
@@ -127,6 +115,18 @@ passing an instance of a command to the `output` method:
 public function handle()
 {
     Terminal::output($this)->run('echo Hello, World');
+}
+```
+
+### Output via Symfony Console Command
+
+If you run Terminal from the Symfony's console command, you may display the output by
+passing an instance of an output to the `output` method:
+
+```php
+protected function execute(InputInterface $input, OutputInterface $output)
+{
+    Terminal::output($output)->run('echo Hello, World');
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ An Elegant wrapper around Symfony's Process component.
     - [Output to Array](#output-to-array)
     - [Output Stream (Recommended)](#output-stream)
     - [Output Lines](#output-lines)
+    - [Output with Symfony Console Command](#output-with-symfony-console-command)
+    - [Output with Laravel Artisan Command](#output-with-laravel-artisan-command)
     - [Throwing Exceptions](#throwing-exceptions)
 - [Data](#data)
 - [Working Directory](#working-directory)
@@ -102,6 +104,30 @@ Alternatively, you may use the `content` method to get the contents of the line:
 
 ```php
 $line->content();
+```
+
+### Output with Symfony Console Command
+
+If you are running Terminal from the Symfony's console command, you may display the output by
+passing an instance of an output to the `output` method:
+
+```php
+protected function execute(InputInterface $input, OutputInterface $output)
+{
+    Terminal::output($output)->run('echo Hello, World');
+}
+```
+
+### Output with Laravel Artisan Command
+
+If you are running Terminal from the Laravel's Artisan command, you may display the output by
+passing an instance of a command to the `output` method:
+
+```php
+public function handle()
+{
+    Terminal::output($this)->run('echo Hello, World');
+}
 ```
 
 ### Throwing Exceptions

--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ $line->content();
 
 ### Output via Laravel Artisan Command
 
-If you are running Terminal from the Laravel's Artisan command, you may display the output by
-passing an instance of a command to the `output` method:
+If you run Terminal from the Laravel's Artisan command, you may send the output to the console by
+passing an instance of the Command to the `output` method:
 
 ```php
 public function handle()
@@ -120,8 +120,8 @@ public function handle()
 
 ### Output via Symfony Console Command
 
-If you run Terminal from the Symfony's console command, you may display the output by
-passing an instance of an output to the `output` method:
+If you run Terminal from the Symfony's Console command, you may send the output to the console by
+passing an instance of the OutputInterface to the `output` method:
 
 ```php
 protected function execute(InputInterface $input, OutputInterface $output)

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ An Elegant wrapper around Symfony's Process component.
     - [Output to Array](#output-to-array)
     - [Output Stream (Recommended)](#output-stream)
     - [Output Lines](#output-lines)
-    - [Output with Symfony Console Command](#output-with-symfony-console-command)
-    - [Output with Laravel Artisan Command](#output-with-laravel-artisan-command)
+    - [Output from Symfony Console Command](#output-from-symfony-console-command)
+    - [Output from Laravel Artisan Command](#output-from-laravel-artisan-command)
     - [Throwing Exceptions](#throwing-exceptions)
 - [Data](#data)
 - [Working Directory](#working-directory)
@@ -106,7 +106,7 @@ Alternatively, you may use the `content` method to get the contents of the line:
 $line->content();
 ```
 
-### Output with Symfony Console Command
+### Output from Symfony Console Command
 
 If you are running Terminal from the Symfony's console command, you may display the output by
 passing an instance of an output to the `output` method:
@@ -118,7 +118,7 @@ protected function execute(InputInterface $input, OutputInterface $output)
 }
 ```
 
-### Output with Laravel Artisan Command
+### Output from Laravel Artisan Command
 
 If you are running Terminal from the Laravel's Artisan command, you may display the output by
 passing an instance of a command to the `output` method:

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -290,6 +290,65 @@ class BuilderTest extends TestCase
     }
 
     /**
+     * Test that termina can handle Symfony' OutputInterface.
+     *
+     * @return void
+     */
+    public function testOutputAsSymfonyOutputInterface()
+    {
+        $output = Mockery::mock('Symfony\Component\Console\Output\OutputInterface', function ($mock) {
+            $mock->shouldReceive('write')
+                ->once()
+                ->with("Hello\n")
+                ->andReturn(null);
+        });
+
+        (new Builder)->output($output)->run('echo Hello');
+    }
+
+    /**
+     * Test that termina can handle Symfony' OutputInterface.
+     *
+     * @return void
+     */
+    public function testOutputAsLaravelCommad()
+    {
+        $output = Mockery::mock('Illuminate\Console\Command', function ($mock) {
+            $mock->shouldReceive('getOutput->write')
+                ->once()
+                ->with("Hello\n")
+                ->andReturn(null);
+        });
+
+        (new Builder)->output($output)->run('echo Hello');
+    }
+
+    /**
+     * Get invalid outputs.
+     *
+     * @return array
+     */
+    public function invalidOutputs(): array
+    {
+        return [
+            [123],
+            ['string'],
+            [new \stdClass],
+        ];
+    }
+
+    /**
+     * Test Terminal output validation.
+     *
+     * @dataProvider invalidOutputs
+     */
+    public function testOutputValidation($output)
+    {
+        $this->expectException('InvalidArgumentException');
+        (new Builder)->output($value)->run('echo Hello');
+    }
+
+    /**
      * Create a new builder instance with a mocked process instance.
      *
      * @param  callable $mocker


### PR DESCRIPTION
This feature allows displaying the output of the Terminal's command via Symfony's Console Command or Laravel's Artisan Command.

### Output from Laravel Artisan Command

If you are running Terminal from the Laravel's Artisan command, you may display the output by
passing an instance of a command to the `output` method:

```php
public function handle()
{
    Terminal::output($this)->run('echo Hello, World');
}
```

### Output from Symfony Console Command

If you are running Terminal from the Symfony's console command, you may display the output by
passing an instance of an output to the `output` method:

```php
protected function execute(InputInterface $input, OutputInterface $output)
{
    Terminal::output($output)->run('echo Hello, World');
}
```