### PR TITLE
Fix `line()` method declaration to ensure PHP 7.1 compatibility

### DIFF
--- a/src/Contracts/Factory.php
+++ b/src/Contracts/Factory.php
@@ -14,13 +14,13 @@ interface Factory
     public static function fake(array $commands = []);
 
     /**
-     * Create a new output line instance.
+     * Create a new output line instance (or array of instances)
      *
-     * @param  string  $content
+     * @param  mixed  $content
      * @param  string  $type
-     * @return \TitasGailius\Terminal\OutputLine
+     * @return \TitasGailius\Terminal\OutputLine|\TitasGailius\Terminal\OutputLine[]
      */
-    public static function line(string $content, string $type = Process::OUT);
+    public static function line($content, string $type = Process::OUT);
     /**
      * Create a new error line.
      *

--- a/src/Terminal.php
+++ b/src/Terminal.php
@@ -43,7 +43,7 @@ class Terminal implements Factory
      * Create a fake response.
      *
      * @param  mixed $lines
-     * @return \TitasGailius\Terminal\Fakes\ResponseFakeBuilder
+     * @return \TitasGailius\Terminal\Fakes\ResponseFake
      */
     public static function response($lines = null, $process = null)
     {
@@ -62,7 +62,7 @@ class Terminal implements Factory
      * Parse given lines.
      *
      * @param  mixed $lines
-     * @return array
+     * @return OutputLine[]
      */
     public static function lines($lines, string $type = Process::OUT)
     {
@@ -72,11 +72,11 @@ class Terminal implements Factory
     }
 
     /**
-     * Create a new output line.
+     * Create new output line(s)
      *
      * @param  mixed  $content
      * @param  string  $type
-     * @return \TitasGailius\Terminal\OutputLine
+     * @return OutputLine|OutputLine[]
      */
     public static function line($content = '', string $type = Process::OUT)
     {
@@ -108,7 +108,7 @@ class Terminal implements Factory
     /**
      * Get an instance of the Process builder class.
      *
-     * @return \TitasGailius\Terminal\Builder|\TitasGailius\Terminal\BuilderFake
+     * @return \TitasGailius\Terminal\Builder|\TitasGailius\Terminal\Fakes\BuilderFake
      */
     public static function builder()
     {
@@ -124,7 +124,7 @@ class Terminal implements Factory
      *
      * @param  string  $method
      * @param  array  $parameters
-     * @return \TitasGailius\Terminal\Builder|\TitasGailius\Terminal\BuilderFake
+     * @return \TitasGailius\Terminal\Builder|\TitasGailius\Terminal\Fakes\BuilderFake
      */
     public static function __callStatic(string $method, array $parameters)
     {


### PR DESCRIPTION
Running in PHP 7.1 produces signature mismatch error:
```
Declaration must be compatible with Factory::line(content: string, [type: string = Process::OUT]).
```

(From PHP 7.2, the current style is allowed — but `symfony/console` 4.4 only requires PHP 7.1.)

This PR updates the method signature for `Terminal::line()` to match `Factory::line()` (and also updates a couple docblocks).