### PR TITLE
Add assertion to check that a given command was not executed

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,14 @@ Terminal::run('php artisan migrate');
 Terminal::assertExecuted('php artisan migrate');
 ```
 
+Alternatively you can also check that a given command was not executed. You may accomplish this by calling the `Terminal::assertNotExecuted` method after calling `Terminal::fake`.
+
+```php
+Terminal::fake();
+
+Terminal::assertNotExecuted('php artisan migrate');
+```
+
 ### Mocking Symfony Process
 
 If you need to mock the underlying Symfony's Process, you may use the Terminal's `response` method.

--- a/src/Fakes/BuilderFake.php
+++ b/src/Fakes/BuilderFake.php
@@ -123,4 +123,15 @@ class BuilderFake extends Builder
             'The command was executed %s times instead of expected %s times.', $count, $times
         ));
     }
+
+    /**
+     * Assert that a given command was not executed.
+     *
+     * @param  mixed  $command
+     * @return void
+     */
+    public static function assertNotExecuted($command)
+    {
+        self::assertExecuted($command, 0);
+    }
 }

--- a/tests/FakeTerminalTest.php
+++ b/tests/FakeTerminalTest.php
@@ -5,6 +5,7 @@ namespace TitasGailius\Terminal\Tests;
 use Mockery;
 use DateTime;
 use DateInterval;
+use PHPUnit\Framework\ExpectationFailedException;
 use TitasGailius\Terminal\Builder;
 use TitasGailius\Terminal\Terminal;
 use Symfony\Component\Process\Process;
@@ -41,6 +42,23 @@ class FakeTerminalTest extends TestCase
     }
 
     /**
+     * Test that Terminal can assert that a given command was not executed.
+     *
+     * @return void
+     */
+    public function testAssertNotExecuted()
+    {
+        Terminal::fake();
+
+        Terminal::assertNotExecuted($expected = 'echo "Hello, World"');
+
+        Terminal::execute($expected);
+
+        $this->expectException(ExpectationFailedException::class);
+        Terminal::assertNotExecuted($expected = 'echo "Hello, World"');
+    }
+
+    /**
      * Test that Terminal can capture and assert executions using a custom filter.
      *
      * @return void
@@ -52,6 +70,29 @@ class FakeTerminalTest extends TestCase
         Terminal::execute($expected = 'echo "Hello, World"');
 
         Terminal::assertExecuted(function ($captured) use ($expected) {
+            return $captured->toString() == $expected;
+        });
+    }
+
+    /**
+     * Test that Terminal can assert that a given command was not executed using a custom filter.
+     *
+     * @return void
+     */
+    public function testAssertNotExecutedUsingCustomFilter()
+    {
+        Terminal::fake();
+
+        $expected = 'echo "Hello, World"';
+
+        Terminal::assertNotExecuted(function ($captured) use ($expected) {
+            return $captured->toString() == $expected;
+        });
+
+        Terminal::execute($expected);
+
+        $this->expectException(ExpectationFailedException::class);
+        Terminal::assertNotExecuted(function ($captured) use ($expected) {
             return $captured->toString() == $expected;
         });
     }


### PR DESCRIPTION
Hey there,

I thought this might be a nice little addition to make our tests a little bit cleaner. It simply checks that a given command was not executed (as a wrapper for the asserExecuted method). 

If you don't want to merge this, feel free to close the PR.

Have a nice day,
Jordan